### PR TITLE
Refactor BaseTool to be an abstract class with event handling and utility methods for drawing tools.

### DIFF
--- a/src/tools/base-tool.ts
+++ b/src/tools/base-tool.ts
@@ -1,1 +1,49 @@
-export class BaseTool {}
+export abstract class BaseTool {
+  protected canvas: HTMLCanvasElement;
+  protected ctx: CanvasRenderingContext2D;
+  protected isActive: boolean = false;
+  protected isDrawing: boolean = false;
+
+  constructor(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+    this.canvas = canvas;
+    this.ctx = ctx;
+  }
+
+  // 툴 활성화/비활성화
+  activate = () => {
+    this.isActive = true;
+    this.addEventListeners();
+  };
+
+  deactivate = () => {
+    this.isActive = false;
+    this.removeEventListeners();
+  };
+
+  // 추상 메서드들 - 각 툴에서 구현 필요
+  abstract onMouseDown(e: MouseEvent): void;
+  abstract onMouseMove(e: MouseEvent): void;
+  abstract onMouseUp(e: MouseEvent): void;
+
+  // 공통 이벤트 리스너 관리
+  private addEventListeners = () => {
+    this.canvas.addEventListener("mousedown", this.onMouseDown);
+    this.canvas.addEventListener("mousemove", this.onMouseMove);
+    this.canvas.addEventListener("mouseup", this.onMouseUp);
+  };
+
+  private removeEventListeners = () => {
+    this.canvas.removeEventListener("mousedown", this.onMouseDown);
+    this.canvas.removeEventListener("mousemove", this.onMouseMove);
+    this.canvas.removeEventListener("mouseup", this.onMouseUp);
+  };
+
+  // 유틸리티 메서드
+  protected getMousePos = (e: MouseEvent) => {
+    const rect = this.canvas.getBoundingClientRect();
+    return {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,1 +1,2 @@
 export * from "./base-tool";
+export * from "./line-tool";

--- a/src/tools/line-tool.ts
+++ b/src/tools/line-tool.ts
@@ -1,0 +1,16 @@
+import { BaseTool } from "./base-tool";
+
+export class LineTool extends BaseTool {
+  components: [] = [];
+
+  constructor(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+    super(canvas, ctx);
+    this.components = [];
+  }
+
+  onMouseDown = (e: MouseEvent) => {};
+  onMouseMove = (e: MouseEvent) => {};
+  onMouseUp = (e: MouseEvent) => {};
+
+  appendComponent = () => {};
+}


### PR DESCRIPTION
This pull request introduces a foundational refactor to the tool system in the codebase, transitioning `BaseTool` into an abstract class and adding a new `LineTool` implementation. These changes improve the extensibility and structure of the tool framework.

### Refactor of `BaseTool`:

* [`src/tools/base-tool.ts`](diffhunk://#diff-c099428c2d275936a0b07debfa87fb2713c88614c91a7950f4a350389c08a8f6L1-R49): Transformed `BaseTool` into an abstract class, added properties (`canvas`, `ctx`, `isActive`, `isDrawing`), lifecycle methods (`activate`, `deactivate`), abstract methods (`onMouseDown`, `onMouseMove`, `onMouseUp`), and utility methods (`getMousePos`). This provides a standardized interface for all tools.

### Addition of `LineTool`:

* [`src/tools/line-tool.ts`](diffhunk://#diff-6f39110106ea2fd3541c522f20fc246b6484642adeb51509f10112355c0e6005R1-R16): Implemented a new tool, `LineTool`, extending `BaseTool`. This includes placeholder methods for mouse event handling and a `components` property for future functionality.
* [`src/tools/index.ts`](diffhunk://#diff-a7cc19a6bb39b048b05c5dd7812537802e591624e72321e0ce4778b18d4bf7e1R2): Updated exports to include the newly added `LineTool`.