### PR TITLE
Add BaseComponent and Line classes for canvas drawing functionality

### DIFF
--- a/development/index.html
+++ b/development/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
+    <button id="line-button">Line button</button>
     <canvas id="canvas"></canvas>
   </body>
   <script type="module" src="./source/app.js"></script>

--- a/development/styles.css
+++ b/development/styles.css
@@ -20,3 +20,10 @@ canvas {
   width: 100%;
   height: 100%;
 }
+
+#line-button {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 10px 30px;
+}

--- a/src/components/base-component.ts
+++ b/src/components/base-component.ts
@@ -1,0 +1,17 @@
+export abstract class BaseComponent {
+  abstract readonly name: string;
+
+  protected canvas: HTMLCanvasElement;
+  protected ctx: CanvasRenderingContext2D;
+  protected isDrag: boolean = false;
+
+  constructor(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+    this.canvas = canvas;
+    this.ctx = ctx;
+  }
+
+  abstract onMouseDown(e: MouseEvent): void;
+  abstract onMouseMove(e: MouseEvent): void;
+  abstract onMouseUp(e: MouseEvent): void;
+  abstract draw(): void;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from "./base-component";
+export * from "./line";

--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -1,0 +1,37 @@
+import { BaseComponent } from "./base-component";
+
+interface Props {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  position: {
+    x1: number;
+    y1: number;
+    cx: number;
+    cy: number;
+    x2: number;
+    y2: number;
+  };
+}
+
+export class Line extends BaseComponent {
+  name: string = "line";
+  position: Props["position"];
+
+  constructor({ canvas, ctx, position }: Props) {
+    super(canvas, ctx);
+    this.position = position;
+  }
+
+  onMouseDown = (e: MouseEvent) => {};
+  onMouseMove = (e: MouseEvent) => {};
+  onMouseUp = (e: MouseEvent) => {};
+
+  draw = () => {
+    this.ctx.beginPath();
+    this.ctx.moveTo(this.position.x1, this.position.y1);
+    this.ctx.lineTo(this.position.x2, this.position.y2);
+    this.ctx.strokeStyle = "black";
+    this.ctx.stroke();
+    this.ctx.closePath();
+  };
+}


### PR DESCRIPTION
This pull request introduces a new `Line` component for drawing lines on a canvas, along with foundational changes to support reusable components. The most important changes include adding a base abstract class for components, implementing the `Line` component, and updating the HTML and CSS to include a button for interacting with the `Line` component.

### Component Architecture Enhancements:
* [`src/components/base-component.ts`](diffhunk://#diff-e63af5bfdca880e98e9946543c0e034e90256f9f825d294552451f8af8d8b774R1-R17): Added an abstract `BaseComponent` class to define a reusable structure for canvas-based components, including methods for mouse event handling and rendering.
* [`src/components/line.ts`](diffhunk://#diff-291a4daab7fa5845ea4fd343a3fde08403f2380369555f6579ef8d025ebfce43R1-R37): Implemented the `Line` component, extending `BaseComponent` to enable drawing lines on the canvas using specified coordinates.

### Code Organization:
* [`src/components/index.ts`](diffhunk://#diff-7fd43b0b162a214d655a8176a345b983bfa23ff95be8e4059e587cf9db3fc51fR1-R2): Exported the `BaseComponent` and `Line` classes to facilitate modular imports.

### UI Updates:
* [`development/index.html`](diffhunk://#diff-f03f8fee41b117bc6454d9a90340379fba76aa1e0eb71add77683531a87211a5R10): Added a new button (`#line-button`) to the HTML for interacting with the `Line` component.
* [`development/styles.css`](diffhunk://#diff-85af667bb8182f4be0ed437d08eed4c40abfc234b3a9aa894d2870e67ded9ccaR23-R29): Styled the `#line-button` with absolute positioning and padding for better visibility and usability.