### PR TITLE
Refactor line resizing logic to handle edge directions and improve position calculations

### DIFF
--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -313,11 +313,11 @@ export class Line extends BaseComponent<LinePosition> {
     1;
     this.ctx.save();
     this.ctx.beginPath();
-    this.ctx.moveTo(x1 - this.multiDragPadding, y1 - this.multiDragPadding);
-    this.ctx.lineTo(x2 + this.multiDragPadding, y1 - this.multiDragPadding);
-    this.ctx.lineTo(x2 + this.multiDragPadding, y2 + this.multiDragPadding);
-    this.ctx.lineTo(x1 - this.multiDragPadding, y2 + this.multiDragPadding);
-    this.ctx.lineTo(x1 - this.multiDragPadding, y1 - this.multiDragPadding);
+    this.ctx.moveTo(x1, y1);
+    this.ctx.lineTo(x2, y1);
+    this.ctx.lineTo(x2, y2);
+    this.ctx.lineTo(x1, y2);
+    this.ctx.lineTo(x1, y1);
     this.ctx.strokeStyle = "rgba(105, 105, 230, 0.5)";
     this.ctx.stroke();
     this.ctx.closePath();

--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -163,17 +163,17 @@ export class Line extends BaseComponent<LinePosition> {
   resizeComponent = (mouseDistance: MousePoint, multiSelectRange: DragRange, edgeDirection: EdgeDirection) => {
     /** Line */
     if (this.type === "line") {
-      // 왼쪽 리사이즈
+      // Left resize
       if (edgeDirection === "left") {
         const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
         const newTotalRangeX = totalRangeX - mouseDistance.x;
         const scale = newTotalRangeX / totalRangeX;
 
-        // 선택 영역 끝점 기준으로 상대 위치 계산
+        // Calculate relative positions based on end point of selection area
         const relativeX1 = this.originPosition.x1 - multiSelectRange.x2;
         const relativeX2 = this.originPosition.x2 - multiSelectRange.x2;
 
-        // 모든 점들을 같은 비율로 조정
+        // Adjust all points with the same scale
         this.position = {
           ...this.position,
           x1: multiSelectRange.x2 + relativeX1 * scale,
@@ -182,17 +182,17 @@ export class Line extends BaseComponent<LinePosition> {
         };
       }
 
-      // 오른쪽 리사이즈
+      // Right resize
       if (edgeDirection === "right") {
         const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
         const newTotalRangeX = totalRangeX + mouseDistance.x;
         const scale = newTotalRangeX / totalRangeX;
 
-        // 선택 영역 시작점 기준으로 상대 위치 계산
+        // Calculate relative positions based on start point of selection area
         const relativeX1 = this.originPosition.x1 - multiSelectRange.x1;
         const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
 
-        // 모든 점들을 같은 비율로 조정
+        // Adjust all points with the same scale
         this.position = {
           ...this.position,
           x1: multiSelectRange.x1 + relativeX1 * scale,
@@ -201,17 +201,17 @@ export class Line extends BaseComponent<LinePosition> {
         };
       }
 
-      // 위쪽 리사이즈
+      // Top resize
       if (edgeDirection === "top") {
         const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
         const newTotalRangeY = totalRangeY - mouseDistance.y;
         const scale = newTotalRangeY / totalRangeY;
 
-        // 선택 영역 끝점 기준으로 상대 위치 계산
+        // Calculate relative positions based on end point of selection area
         const relativeY1 = this.originPosition.y1 - multiSelectRange.y2;
         const relativeY2 = this.originPosition.y2 - multiSelectRange.y2;
 
-        // 모든 점들을 같은 비율로 조정
+        // Adjust all points with the same scale
         this.position = {
           ...this.position,
           y1: multiSelectRange.y2 + relativeY1 * scale,
@@ -220,17 +220,17 @@ export class Line extends BaseComponent<LinePosition> {
         };
       }
 
-      // 아래쪽 리사이즈
+      // Bottom resize
       if (edgeDirection === "bottom") {
         const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
         const newTotalRangeY = totalRangeY + mouseDistance.y;
         const scale = newTotalRangeY / totalRangeY;
 
-        // 선택 영역 시작점 기준으로 상대 위치 계산
+        // Calculate relative positions based on start point of selection area
         const relativeY1 = this.originPosition.y1 - multiSelectRange.y1;
         const relativeY2 = this.originPosition.y2 - multiSelectRange.y1;
 
-        // 모든 점들을 같은 비율로 조정
+        // Adjust all points with the same scale
         this.position = {
           ...this.position,
           y1: multiSelectRange.y1 + relativeY1 * scale,
@@ -241,23 +241,23 @@ export class Line extends BaseComponent<LinePosition> {
     }
 
     /**
-     * 상하 리사이즈일 때
+     * Vertical resize
      */
     /**
-     * 대각선 리사이즈일 때
+     * Diagonal resize
      */
     /***************************** */
     /***************************** */
     /** Curve */
     /**
-     * 좌우 리사이즈일 때
+     * Horizontal resize
      * totalX
      */
     /**
-     * 상하 리사이즈일 때
+     * Vertical resize
      */
     /**
-     * 대각선 리사이즈일 때
+     * Diagonal resize
      */
   };
 

--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -166,53 +166,71 @@ export class Line extends BaseComponent<LinePosition> {
      * 좌우 리사이즈일 때
      * totalX
      */
-    if (edgeDirection === "right") {
-      const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
-      const newTotalRangeX = totalRangeX + mouseDistance.x;
-      const scale = newTotalRangeX / totalRangeX;
+    if (this.type === "line") {
+      if (edgeDirection === "left") {
+        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
+        const newTotalRangeX = totalRangeX - mouseDistance.x;
+        const scale = newTotalRangeX / totalRangeX;
 
-      // 선택 영역의 시작점(x1)을 기준으로 상대적 위치를 계산하여 스케일 적용
-      const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
-      const relativeCx = this.originPosition.cx - multiSelectRange.x1;
+        // 선택 영역의 끝점(x2)을 기준으로 상대적 위치를 계산하여 스케일 적용
+        const relativeX1 = this.originPosition.x1 - multiSelectRange.x2;
 
-      this.position = {
-        ...this.position,
-        x2: multiSelectRange.x1 + relativeX2 * scale,
-        cx: multiSelectRange.x1 + relativeCx * scale,
-      };
-    }
+        this.position = {
+          ...this.position,
+          x1: multiSelectRange.x2 + relativeX1 * scale,
+          cx: (this.position.x2 + multiSelectRange.x2 + relativeX1 * scale) / 2,
+        };
+      }
 
-    if (edgeDirection === "left") {
-      const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
-      const newTotalRangeX = totalRangeX - mouseDistance.x;
-      const scale = newTotalRangeX / totalRangeX;
+      if (edgeDirection === "right") {
+        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
+        const newTotalRangeX = totalRangeX + mouseDistance.x;
+        const scale = newTotalRangeX / totalRangeX;
 
-      // 선택 영역의 끝점(x2)을 기준으로 상대적 위치를 계산하여 스케일 적용
-      const relativeX1 = this.originPosition.x1 - multiSelectRange.x2;
-      const relativeCx = this.originPosition.cx - multiSelectRange.x2;
+        const relativeX1 = this.originPosition.x1 - multiSelectRange.x1;
+        const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
 
-      this.position = {
-        ...this.position,
-        x1: multiSelectRange.x2 + relativeX1 * scale,
-        cx: multiSelectRange.x2 + relativeCx * scale,
-      };
-    }
+        this.position = {
+          ...this.position,
+          x1: multiSelectRange.x1 + relativeX1 * scale,
+          x2: multiSelectRange.x1 + relativeX2 * scale,
+          cx: (multiSelectRange.x1 + relativeX1 * scale + multiSelectRange.x1 + relativeX2 * scale) / 2,
+        };
+      }
 
-    if (edgeDirection === "top") {
-      const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
-      const newTotalRangeY = totalRangeY - mouseDistance.y;
-      const scale = newTotalRangeY / totalRangeY;
+      if (edgeDirection === "top") {
+        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
+        const newTotalRangeY = totalRangeY - mouseDistance.y;
+        const scale = newTotalRangeY / totalRangeY;
 
-      // 선택 영역의 끝점(y2)을 기준으로 상대적 위치를 계산
-      const relativeY1 = this.originPosition.y1 - multiSelectRange.y2;
-      const relativeY2 = this.originPosition.y2 - multiSelectRange.y2;
+        // 선택 영역의 끝점(y2)을 기준으로 상대적 위치를 계산
+        const relativeY1 = this.originPosition.y1 - multiSelectRange.y2;
+        const relativeY2 = this.originPosition.y2 - multiSelectRange.y2;
 
-      this.position = {
-        ...this.position,
-        y1: multiSelectRange.y2 + relativeY1 * scale,
-        y2: multiSelectRange.y2 + relativeY2 * scale,
-        cy: multiSelectRange.y2 + relativeY2 * scale,
-      };
+        this.position = {
+          ...this.position,
+          y1: multiSelectRange.y2 + relativeY1 * scale,
+          y2: multiSelectRange.y2 + relativeY2 * scale,
+          cy: (multiSelectRange.y2 + relativeY1 * scale + multiSelectRange.y2 + relativeY2 * scale) / 2,
+        };
+      }
+
+      if (edgeDirection === "bottom") {
+        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
+        const newTotalRangeY = totalRangeY + mouseDistance.y;
+        const scale = newTotalRangeY / totalRangeY;
+
+        // 선택 영역의 끝점(y1)을 기준으로 상대적 위치를 계산
+        const relativeY1 = this.originPosition.y1 - multiSelectRange.y1;
+        const relativeY2 = this.originPosition.y2 - multiSelectRange.y1;
+
+        this.position = {
+          ...this.position,
+          y1: multiSelectRange.y1 + relativeY1 * scale,
+          y2: multiSelectRange.y1 + relativeY2 * scale,
+          cy: (multiSelectRange.y1 + relativeY1 * scale + multiSelectRange.y1 + relativeY2 * scale) / 2,
+        };
+      }
     }
 
     /**

--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -163,24 +163,7 @@ export class Line extends BaseComponent<LinePosition> {
   resizeComponent = (mouseDistance: MousePoint, multiSelectRange: DragRange, edgeDirection: EdgeDirection) => {
     /** Line */
     if (this.type === "line") {
-      if (edgeDirection === "right") {
-        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
-        const newTotalRangeX = totalRangeX + mouseDistance.x;
-        const scale = newTotalRangeX / totalRangeX;
-
-        // 선택 영역 시작점 기준으로 상대 위치 계산
-        const relativeX1 = this.originPosition.x1 - multiSelectRange.x1;
-        const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
-
-        // 모든 점들을 같은 비율로 조정
-        this.position = {
-          ...this.position,
-          x1: multiSelectRange.x1 + relativeX1 * scale,
-          x2: multiSelectRange.x1 + relativeX2 * scale,
-          cx: multiSelectRange.x1 + ((relativeX1 + relativeX2) / 2) * scale,
-        };
-      }
-
+      // 왼쪽 리사이즈
       if (edgeDirection === "left") {
         const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
         const newTotalRangeX = totalRangeX - mouseDistance.x;
@@ -199,24 +182,26 @@ export class Line extends BaseComponent<LinePosition> {
         };
       }
 
-      if (edgeDirection === "bottom") {
-        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
-        const newTotalRangeY = totalRangeY + mouseDistance.y;
-        const scale = newTotalRangeY / totalRangeY;
+      // 오른쪽 리사이즈
+      if (edgeDirection === "right") {
+        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
+        const newTotalRangeX = totalRangeX + mouseDistance.x;
+        const scale = newTotalRangeX / totalRangeX;
 
         // 선택 영역 시작점 기준으로 상대 위치 계산
-        const relativeY1 = this.originPosition.y1 - multiSelectRange.y1;
-        const relativeY2 = this.originPosition.y2 - multiSelectRange.y1;
+        const relativeX1 = this.originPosition.x1 - multiSelectRange.x1;
+        const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
 
         // 모든 점들을 같은 비율로 조정
         this.position = {
           ...this.position,
-          y1: multiSelectRange.y1 + relativeY1 * scale,
-          y2: multiSelectRange.y1 + relativeY2 * scale,
-          cy: multiSelectRange.y1 + ((relativeY1 + relativeY2) / 2) * scale,
+          x1: multiSelectRange.x1 + relativeX1 * scale,
+          x2: multiSelectRange.x1 + relativeX2 * scale,
+          cx: multiSelectRange.x1 + ((relativeX1 + relativeX2) / 2) * scale,
         };
       }
 
+      // 위쪽 리사이즈
       if (edgeDirection === "top") {
         const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
         const newTotalRangeY = totalRangeY - mouseDistance.y;
@@ -232,6 +217,25 @@ export class Line extends BaseComponent<LinePosition> {
           y1: multiSelectRange.y2 + relativeY1 * scale,
           y2: multiSelectRange.y2 + relativeY2 * scale,
           cy: multiSelectRange.y2 + ((relativeY1 + relativeY2) / 2) * scale,
+        };
+      }
+
+      // 아래쪽 리사이즈
+      if (edgeDirection === "bottom") {
+        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
+        const newTotalRangeY = totalRangeY + mouseDistance.y;
+        const scale = newTotalRangeY / totalRangeY;
+
+        // 선택 영역 시작점 기준으로 상대 위치 계산
+        const relativeY1 = this.originPosition.y1 - multiSelectRange.y1;
+        const relativeY2 = this.originPosition.y2 - multiSelectRange.y1;
+
+        // 모든 점들을 같은 비율로 조정
+        this.position = {
+          ...this.position,
+          y1: multiSelectRange.y1 + relativeY1 * scale,
+          y2: multiSelectRange.y1 + relativeY2 * scale,
+          cy: multiSelectRange.y1 + ((relativeY1 + relativeY2) / 2) * scale,
         };
       }
     }

--- a/src/components/line.ts
+++ b/src/components/line.ts
@@ -162,56 +162,40 @@ export class Line extends BaseComponent<LinePosition> {
 
   resizeComponent = (mouseDistance: MousePoint, multiSelectRange: DragRange, edgeDirection: EdgeDirection) => {
     /** Line */
-    /**
-     * 좌우 리사이즈일 때
-     * totalX
-     */
     if (this.type === "line") {
-      if (edgeDirection === "left") {
-        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
-        const newTotalRangeX = totalRangeX - mouseDistance.x;
-        const scale = newTotalRangeX / totalRangeX;
-
-        // 선택 영역의 끝점(x2)을 기준으로 상대적 위치를 계산하여 스케일 적용
-        const relativeX1 = this.originPosition.x1 - multiSelectRange.x2;
-
-        this.position = {
-          ...this.position,
-          x1: multiSelectRange.x2 + relativeX1 * scale,
-          cx: (this.position.x2 + multiSelectRange.x2 + relativeX1 * scale) / 2,
-        };
-      }
-
       if (edgeDirection === "right") {
         const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
         const newTotalRangeX = totalRangeX + mouseDistance.x;
         const scale = newTotalRangeX / totalRangeX;
 
+        // 선택 영역 시작점 기준으로 상대 위치 계산
         const relativeX1 = this.originPosition.x1 - multiSelectRange.x1;
         const relativeX2 = this.originPosition.x2 - multiSelectRange.x1;
 
+        // 모든 점들을 같은 비율로 조정
         this.position = {
           ...this.position,
           x1: multiSelectRange.x1 + relativeX1 * scale,
           x2: multiSelectRange.x1 + relativeX2 * scale,
-          cx: (multiSelectRange.x1 + relativeX1 * scale + multiSelectRange.x1 + relativeX2 * scale) / 2,
+          cx: multiSelectRange.x1 + ((relativeX1 + relativeX2) / 2) * scale,
         };
       }
 
-      if (edgeDirection === "top") {
-        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
-        const newTotalRangeY = totalRangeY - mouseDistance.y;
-        const scale = newTotalRangeY / totalRangeY;
+      if (edgeDirection === "left") {
+        const totalRangeX = Math.abs(multiSelectRange.x2 - multiSelectRange.x1);
+        const newTotalRangeX = totalRangeX - mouseDistance.x;
+        const scale = newTotalRangeX / totalRangeX;
 
-        // 선택 영역의 끝점(y2)을 기준으로 상대적 위치를 계산
-        const relativeY1 = this.originPosition.y1 - multiSelectRange.y2;
-        const relativeY2 = this.originPosition.y2 - multiSelectRange.y2;
+        // 선택 영역 끝점 기준으로 상대 위치 계산
+        const relativeX1 = this.originPosition.x1 - multiSelectRange.x2;
+        const relativeX2 = this.originPosition.x2 - multiSelectRange.x2;
 
+        // 모든 점들을 같은 비율로 조정
         this.position = {
           ...this.position,
-          y1: multiSelectRange.y2 + relativeY1 * scale,
-          y2: multiSelectRange.y2 + relativeY2 * scale,
-          cy: (multiSelectRange.y2 + relativeY1 * scale + multiSelectRange.y2 + relativeY2 * scale) / 2,
+          x1: multiSelectRange.x2 + relativeX1 * scale,
+          x2: multiSelectRange.x2 + relativeX2 * scale,
+          cx: multiSelectRange.x2 + ((relativeX1 + relativeX2) / 2) * scale,
         };
       }
 
@@ -220,15 +204,34 @@ export class Line extends BaseComponent<LinePosition> {
         const newTotalRangeY = totalRangeY + mouseDistance.y;
         const scale = newTotalRangeY / totalRangeY;
 
-        // 선택 영역의 끝점(y1)을 기준으로 상대적 위치를 계산
+        // 선택 영역 시작점 기준으로 상대 위치 계산
         const relativeY1 = this.originPosition.y1 - multiSelectRange.y1;
         const relativeY2 = this.originPosition.y2 - multiSelectRange.y1;
 
+        // 모든 점들을 같은 비율로 조정
         this.position = {
           ...this.position,
           y1: multiSelectRange.y1 + relativeY1 * scale,
           y2: multiSelectRange.y1 + relativeY2 * scale,
-          cy: (multiSelectRange.y1 + relativeY1 * scale + multiSelectRange.y1 + relativeY2 * scale) / 2,
+          cy: multiSelectRange.y1 + ((relativeY1 + relativeY2) / 2) * scale,
+        };
+      }
+
+      if (edgeDirection === "top") {
+        const totalRangeY = Math.abs(multiSelectRange.y2 - multiSelectRange.y1);
+        const newTotalRangeY = totalRangeY - mouseDistance.y;
+        const scale = newTotalRangeY / totalRangeY;
+
+        // 선택 영역 끝점 기준으로 상대 위치 계산
+        const relativeY1 = this.originPosition.y1 - multiSelectRange.y2;
+        const relativeY2 = this.originPosition.y2 - multiSelectRange.y2;
+
+        // 모든 점들을 같은 비율로 조정
+        this.position = {
+          ...this.position,
+          y1: multiSelectRange.y2 + relativeY1 * scale,
+          y2: multiSelectRange.y2 + relativeY2 * scale,
+          cy: multiSelectRange.y2 + ((relativeY1 + relativeY2) / 2) * scale,
         };
       }
     }

--- a/src/managers/component-manager.ts
+++ b/src/managers/component-manager.ts
@@ -182,34 +182,125 @@ export class ComponentManager {
       y: mousePos.y - this.tempPosition.y,
     };
 
+    // 왼쪽 리사이즈
     if (this.resizeEdge === "left") {
-      this.multiSelectRange = {
-        ...this.multiSelectRange,
-        x1: this.originMultiSelectRange.x1 + mouseDistance.x,
-      };
+      const newX1 = this.originMultiSelectRange.x1 + mouseDistance.x;
 
-      if (this.multiSelectRange.x1 + this.multiRangePadding + 5 > this.multiSelectRange.x2) {
+      // 왼쪽 벽이 오른쪽 벽에 닿으면 오른쪽 리사이즈로 변경
+      if (newX1 >= this.multiSelectRange.x2 - this.multiRangePadding) {
         this.resizeEdge = "right";
-        this.tempPosition = Object.assign({}, mousePos);
-      }
-    }
+        this.tempPosition = mousePos;
 
-    if (this.resizeEdge === "right") {
+        // 현재 선택 영역의 크기를 유지
+        const currentWidth = this.multiSelectRange.x2 - this.multiSelectRange.x1;
+
+        this.originMultiSelectRange = {
+          ...this.multiSelectRange,
+          x1: this.multiSelectRange.x2 - currentWidth,
+          x2: this.multiSelectRange.x2,
+        };
+
+        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        for (const component of this.selectedComponents) {
+          component.initialPosition();
+        }
+        return;
+      }
+
       this.multiSelectRange = {
         ...this.multiSelectRange,
-        x2: this.originMultiSelectRange.x2 + mouseDistance.x,
+        x1: newX1,
       };
+    }
 
-      if (this.multiSelectRange.x2 - this.multiRangePadding - 5 < this.multiSelectRange.x1) {
+    // 오른쪽 리사이즈
+    if (this.resizeEdge === "right") {
+      const newX2 = this.originMultiSelectRange.x2 + mouseDistance.x;
+
+      // 오른쪽 벽이 왼쪽 벽에 닿으면 왼쪽 리사이즈로 변경
+      if (newX2 <= this.multiSelectRange.x1 + this.multiRangePadding) {
         this.resizeEdge = "left";
-        this.tempPosition = Object.assign({}, mousePos);
+        this.tempPosition = mousePos;
+
+        // 현재 선택 영역의 크기를 유지
+        const currentWidth = this.multiSelectRange.x2 - this.multiSelectRange.x1;
+        this.originMultiSelectRange = {
+          ...this.multiSelectRange,
+          x1: this.multiSelectRange.x1,
+          x2: this.multiSelectRange.x1 + currentWidth,
+        };
+
+        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        for (const component of this.selectedComponents) {
+          component.initialPosition();
+        }
+        return;
       }
+
+      this.multiSelectRange = {
+        ...this.multiSelectRange,
+        x2: newX2,
+      };
     }
 
+    // 위쪽 리사이즈
     if (this.resizeEdge === "top") {
+      const newY1 = this.originMultiSelectRange.y1 + mouseDistance.y;
+
+      // 위쪽 벽이 아래쪽 벽에 닿으면 아래쪽 리사이즈로 변경
+      if (newY1 >= this.multiSelectRange.y2 - this.multiRangePadding) {
+        this.resizeEdge = "bottom";
+        this.tempPosition = mousePos;
+
+        // 현재 선택 영역의 크기를 유지
+        const currentHeight = this.multiSelectRange.y2 - this.multiSelectRange.y1;
+        this.originMultiSelectRange = {
+          ...this.multiSelectRange,
+          y1: this.multiSelectRange.y2 - currentHeight,
+          y2: this.multiSelectRange.y2,
+        };
+
+        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        for (const component of this.selectedComponents) {
+          component.initialPosition();
+        }
+        return;
+      }
+
+      this.multiSelectRange = {
+        ...this.multiSelectRange,
+        y1: newY1,
+      };
     }
 
+    // 아래쪽 리사이즈
     if (this.resizeEdge === "bottom") {
+      const newY2 = this.originMultiSelectRange.y2 + mouseDistance.y;
+
+      // 아래쪽 벽이 위쪽 벽에 닿으면 위쪽 리사이즈로 변경
+      if (newY2 <= this.multiSelectRange.y1 + this.multiRangePadding) {
+        this.resizeEdge = "top";
+        this.tempPosition = mousePos;
+
+        // 현재 선택 영역의 크기를 유지
+        const currentHeight = this.multiSelectRange.y2 - this.multiSelectRange.y1;
+        this.originMultiSelectRange = {
+          ...this.multiSelectRange,
+          y1: this.multiSelectRange.y1,
+          y2: this.multiSelectRange.y1 + currentHeight,
+        };
+
+        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        for (const component of this.selectedComponents) {
+          component.initialPosition();
+        }
+        return;
+      }
+
+      this.multiSelectRange = {
+        ...this.multiSelectRange,
+        y2: newY2,
+      };
     }
 
     for (const component of this.selectedComponents) {

--- a/src/managers/component-manager.ts
+++ b/src/managers/component-manager.ts
@@ -175,12 +175,42 @@ export class ComponentManager {
    * Handle component resizing
    */
   private handleComponentResize = (e: MouseEvent, mousePos: MousePoint) => {
-    if (!this.tempPosition || !this.resizeEdge || !this.originMultiSelectRange) return;
+    if (!this.tempPosition || !this.resizeEdge || !this.originMultiSelectRange || !this.multiSelectRange) return;
 
     const mouseDistance = {
       x: mousePos.x - this.tempPosition.x,
       y: mousePos.y - this.tempPosition.y,
     };
+
+    if (this.resizeEdge === "left") {
+      this.multiSelectRange = {
+        ...this.multiSelectRange,
+        x1: this.originMultiSelectRange.x1 + mouseDistance.x,
+      };
+
+      if (this.multiSelectRange.x1 + this.multiRangePadding + 5 > this.multiSelectRange.x2) {
+        this.resizeEdge = "right";
+        this.tempPosition = Object.assign({}, mousePos);
+      }
+    }
+
+    if (this.resizeEdge === "right") {
+      this.multiSelectRange = {
+        ...this.multiSelectRange,
+        x2: this.originMultiSelectRange.x2 + mouseDistance.x,
+      };
+
+      if (this.multiSelectRange.x2 - this.multiRangePadding - 5 < this.multiSelectRange.x1) {
+        this.resizeEdge = "left";
+        this.tempPosition = Object.assign({}, mousePos);
+      }
+    }
+
+    if (this.resizeEdge === "top") {
+    }
+
+    if (this.resizeEdge === "bottom") {
+    }
 
     for (const component of this.selectedComponents) {
       component.resizeComponent(mouseDistance, this.originMultiSelectRange, this.resizeEdge);

--- a/src/managers/component-manager.ts
+++ b/src/managers/component-manager.ts
@@ -182,16 +182,16 @@ export class ComponentManager {
       y: mousePos.y - this.tempPosition.y,
     };
 
-    // 왼쪽 리사이즈
+    // Left resize
     if (this.resizeEdge === "left") {
       const newX1 = this.originMultiSelectRange.x1 + mouseDistance.x;
 
-      // 왼쪽 벽이 오른쪽 벽에 닿으면 오른쪽 리사이즈로 변경
+      // Switch to right resize when left wall touches right wall
       if (newX1 >= this.multiSelectRange.x2 - this.multiRangePadding) {
         this.resizeEdge = "right";
         this.tempPosition = mousePos;
 
-        // 현재 선택 영역의 크기를 유지
+        // Maintain current selection area size
         const currentWidth = this.multiSelectRange.x2 - this.multiSelectRange.x1;
 
         this.originMultiSelectRange = {
@@ -200,7 +200,7 @@ export class ComponentManager {
           x2: this.multiSelectRange.x2,
         };
 
-        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        // Set current position as originPosition for all components
         for (const component of this.selectedComponents) {
           component.initialPosition();
         }
@@ -213,16 +213,16 @@ export class ComponentManager {
       };
     }
 
-    // 오른쪽 리사이즈
+    // Right resize
     if (this.resizeEdge === "right") {
       const newX2 = this.originMultiSelectRange.x2 + mouseDistance.x;
 
-      // 오른쪽 벽이 왼쪽 벽에 닿으면 왼쪽 리사이즈로 변경
+      // Switch to left resize when right wall touches left wall
       if (newX2 <= this.multiSelectRange.x1 + this.multiRangePadding) {
         this.resizeEdge = "left";
         this.tempPosition = mousePos;
 
-        // 현재 선택 영역의 크기를 유지
+        // Maintain current selection area size
         const currentWidth = this.multiSelectRange.x2 - this.multiSelectRange.x1;
         this.originMultiSelectRange = {
           ...this.multiSelectRange,
@@ -230,7 +230,7 @@ export class ComponentManager {
           x2: this.multiSelectRange.x1 + currentWidth,
         };
 
-        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        // Set current position as originPosition for all components
         for (const component of this.selectedComponents) {
           component.initialPosition();
         }
@@ -243,16 +243,16 @@ export class ComponentManager {
       };
     }
 
-    // 위쪽 리사이즈
+    // Top resize
     if (this.resizeEdge === "top") {
       const newY1 = this.originMultiSelectRange.y1 + mouseDistance.y;
 
-      // 위쪽 벽이 아래쪽 벽에 닿으면 아래쪽 리사이즈로 변경
+      // Switch to bottom resize when top wall touches bottom wall
       if (newY1 >= this.multiSelectRange.y2 - this.multiRangePadding) {
         this.resizeEdge = "bottom";
         this.tempPosition = mousePos;
 
-        // 현재 선택 영역의 크기를 유지
+        // Maintain current selection area size
         const currentHeight = this.multiSelectRange.y2 - this.multiSelectRange.y1;
         this.originMultiSelectRange = {
           ...this.multiSelectRange,
@@ -260,7 +260,7 @@ export class ComponentManager {
           y2: this.multiSelectRange.y2,
         };
 
-        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        // Set current position as originPosition for all components
         for (const component of this.selectedComponents) {
           component.initialPosition();
         }
@@ -273,16 +273,16 @@ export class ComponentManager {
       };
     }
 
-    // 아래쪽 리사이즈
+    // Bottom resize
     if (this.resizeEdge === "bottom") {
       const newY2 = this.originMultiSelectRange.y2 + mouseDistance.y;
 
-      // 아래쪽 벽이 위쪽 벽에 닿으면 위쪽 리사이즈로 변경
+      // Switch to top resize when bottom wall touches top wall
       if (newY2 <= this.multiSelectRange.y1 + this.multiRangePadding) {
         this.resizeEdge = "top";
         this.tempPosition = mousePos;
 
-        // 현재 선택 영역의 크기를 유지
+        // Maintain current selection area size
         const currentHeight = this.multiSelectRange.y2 - this.multiSelectRange.y1;
         this.originMultiSelectRange = {
           ...this.multiSelectRange,
@@ -290,7 +290,7 @@ export class ComponentManager {
           y2: this.multiSelectRange.y1 + currentHeight,
         };
 
-        // 모든 컴포넌트의 현재 위치를 originPosition으로 설정
+        // Set current position as originPosition for all components
         for (const component of this.selectedComponents) {
           component.initialPosition();
         }


### PR DESCRIPTION
This pull request introduces significant improvements to the resizing logic for components, focusing on better handling of edge cases and maintaining consistent behavior during multi-select resizing. Key changes include refining the resize logic for `Line` components, updating the visual rendering of selection areas, and enhancing the `ComponentManager` to handle edge switches during resizing.

### Resizing Logic Enhancements

* **Improved `Line` Component Resizing Logic**:
  - Refactored the `resizeComponent` method in `Line` to handle left, right, top, and bottom resizing more consistently, ensuring proper scaling of all points relative to the selection area's edges.
  - Added logic to calculate relative positions based on the appropriate edge (start or end) of the selection area for each resize direction.

* **Edge Switching During Resizing**:
  - Enhanced the `ComponentManager` to handle scenarios where resizing one edge causes it to cross over another (e.g., left edge crossing the right edge). The system now switches the resize direction dynamically while maintaining the current selection area's size.
  - Implemented this logic for all four edges: left, right, top, and bottom.

### Visual Rendering Updates

* **Selection Area Rendering Simplification**:
  - Simplified the rendering of selection areas by removing the `multiDragPadding` offsets, ensuring a cleaner and more precise visual representation of the selected region.